### PR TITLE
utils.py

### DIFF
--- a/happypanda/utils.py
+++ b/happypanda/utils.py
@@ -411,7 +411,15 @@ class ArchiveFile():
             raise app_constants.CreateArchiveFail
 
     def namelist(self):
-        filelist = self.archive.namelist()
+        filelist= []
+        for x in self.archive.namelist():
+            if x.endswith('/'):
+                filelist.append(x)
+            else:
+                filelist.append(x[:(x.rindex('/')+1)])
+                filelist.append(x)
+        seen = set()
+        filelist = [x for x in filelist if x not in seen and not seen.add(x)]
         return filelist
 
     def is_dir(self, name):


### PR DESCRIPTION
Fixes a problem with some zip archives being detected as empty when they aren't. The zipfile.namelist() method for some reason doesn't return folder paths for some zip files. This fix should maintain list order, but I haven't tested it outside of the isolated .py file (apologies for not knowing best practices, I am noob).

If this could be made into a release build, I'd be super grateful. I lack the know how to do that for myself.